### PR TITLE
增加对<think>标签思考内容兼容

### DIFF
--- a/internal/adk/openai/convert.go
+++ b/internal/adk/openai/convert.go
@@ -437,9 +437,12 @@ func convertChatCompletionResponse(resp *openai.ChatCompletionResponse) (*model.
 	// 处理普通内容，解析第三方特殊工具调用标记
 	if choice.Message.Content != "" {
 		vendorCalls, cleanedText := parseVendorToolCalls(choice.Message.Content)
-		// 添加清理后的文本
-		if cleanedText != "" {
-			content.Parts = append(content.Parts, &genai.Part{Text: cleanedText})
+		// 解析 <think> 标签并映射到 Thought
+		for _, seg := range splitThinkTaggedText(cleanedText) {
+			content.Parts = append(content.Parts, &genai.Part{
+				Text:    seg.Text,
+				Thought: seg.Thought,
+			})
 		}
 		// 将第三方工具调用转换为 FunctionCall
 		for i, vc := range vendorCalls {

--- a/internal/adk/openai/responses_convert.go
+++ b/internal/adk/openai/responses_convert.go
@@ -223,8 +223,11 @@ func convertResponsesResponse(resp *CreateResponseResponse) (*model.LLMResponse,
 				case "output_text":
 					// 解析第三方特殊工具调用标记
 					vendorCalls, cleanedText := parseVendorToolCalls(part.Text)
-					if cleanedText != "" {
-						content.Parts = append(content.Parts, &genai.Part{Text: cleanedText})
+					for _, seg := range splitThinkTaggedText(cleanedText) {
+						content.Parts = append(content.Parts, &genai.Part{
+							Text:    seg.Text,
+							Thought: seg.Thought,
+						})
 					}
 					for i, vc := range vendorCalls {
 						content.Parts = append(content.Parts, &genai.Part{

--- a/internal/adk/openai/think_parser.go
+++ b/internal/adk/openai/think_parser.go
@@ -1,0 +1,169 @@
+package openai
+
+import "strings"
+
+const (
+	thinkOpenTag  = "<think>"
+	thinkCloseTag = "</think>"
+)
+
+type thinkSegment struct {
+	Text    string
+	Thought bool
+}
+
+// splitThinkTaggedText parses a complete text and maps <think>...</think>
+// content into Thought segments.
+func splitThinkTaggedText(text string) []thinkSegment {
+	if text == "" {
+		return nil
+	}
+
+	parser := newThinkTagStreamParser()
+	segments := parser.Feed(text)
+	segments = append(segments, parser.Flush()...)
+	return mergeThinkSegments(segments)
+}
+
+// thinkTagStreamParser incrementally parses <think>...</think> markers.
+type thinkTagStreamParser struct {
+	buffer  string
+	inThink bool
+}
+
+func newThinkTagStreamParser() *thinkTagStreamParser {
+	return &thinkTagStreamParser{}
+}
+
+// Feed parses incremental chunks and returns deterministically parsed segments.
+// Potentially incomplete tag prefixes are kept in internal buffer.
+func (p *thinkTagStreamParser) Feed(chunk string) []thinkSegment {
+	if chunk == "" {
+		return nil
+	}
+
+	p.buffer += chunk
+	var segments []thinkSegment
+
+	for {
+		if p.buffer == "" {
+			break
+		}
+
+		if p.inThink {
+			endIdx := indexFold(p.buffer, thinkCloseTag)
+			if endIdx >= 0 {
+				if endIdx > 0 {
+					segments = append(segments, thinkSegment{
+						Text:    p.buffer[:endIdx],
+						Thought: true,
+					})
+				}
+				p.buffer = p.buffer[endIdx+len(thinkCloseTag):]
+				p.inThink = false
+				continue
+			}
+
+			emit, keep := splitKeepPossibleTagPrefix(p.buffer, thinkCloseTag)
+			if emit != "" {
+				segments = append(segments, thinkSegment{
+					Text:    emit,
+					Thought: true,
+				})
+			}
+			p.buffer = keep
+			break
+		}
+
+		startIdx := indexFold(p.buffer, thinkOpenTag)
+		if startIdx >= 0 {
+			if startIdx > 0 {
+				segments = append(segments, thinkSegment{
+					Text: p.buffer[:startIdx],
+				})
+			}
+			p.buffer = p.buffer[startIdx+len(thinkOpenTag):]
+			p.inThink = true
+			continue
+		}
+
+		emit, keep := splitKeepPossibleTagPrefix(p.buffer, thinkOpenTag)
+		if emit != "" {
+			segments = append(segments, thinkSegment{
+				Text: emit,
+			})
+		}
+		p.buffer = keep
+		break
+	}
+
+	return mergeThinkSegments(segments)
+}
+
+// Flush flushes leftover buffered text, usually called at end-of-stream.
+func (p *thinkTagStreamParser) Flush() []thinkSegment {
+	if p.buffer == "" {
+		return nil
+	}
+
+	segment := thinkSegment{
+		Text:    p.buffer,
+		Thought: p.inThink,
+	}
+	p.buffer = ""
+	p.inThink = false
+
+	if segment.Text == "" {
+		return nil
+	}
+	return []thinkSegment{segment}
+}
+
+func splitKeepPossibleTagPrefix(text, tag string) (emit string, keep string) {
+	if text == "" || len(tag) <= 1 {
+		return text, ""
+	}
+
+	maxSuffix := len(tag) - 1
+	if maxSuffix > len(text) {
+		maxSuffix = len(text)
+	}
+
+	for k := maxSuffix; k > 0; k-- {
+		if strings.EqualFold(text[len(text)-k:], tag[:k]) {
+			return text[:len(text)-k], text[len(text)-k:]
+		}
+	}
+
+	return text, ""
+}
+
+func mergeThinkSegments(segments []thinkSegment) []thinkSegment {
+	if len(segments) == 0 {
+		return nil
+	}
+
+	merged := make([]thinkSegment, 0, len(segments))
+	for _, seg := range segments {
+		if seg.Text == "" {
+			continue
+		}
+
+		n := len(merged)
+		if n > 0 && merged[n-1].Thought == seg.Thought {
+			merged[n-1].Text += seg.Text
+			continue
+		}
+
+		merged = append(merged, seg)
+	}
+	return merged
+}
+
+func indexFold(s, sep string) int {
+	if sep == "" {
+		return 0
+	}
+	return strings.Index(strings.ToLower(s), strings.ToLower(sep))
+}
+

--- a/internal/memory/summarizer.go
+++ b/internal/memory/summarizer.go
@@ -58,6 +58,9 @@ func (s *LLMSummarizer) generate(ctx context.Context, prompt string) (string, er
 		}
 		if resp != nil && resp.Content != nil {
 			for _, part := range resp.Content.Parts {
+				if part.Thought {
+					continue
+				}
 				if part.Text != "" {
 					result += part.Text
 				}

--- a/internal/services/strategy_service.go
+++ b/internal/services/strategy_service.go
@@ -506,6 +506,9 @@ func (s *StrategyService) callLLM(ctx context.Context, prompt string) (string, e
 		}
 		if resp != nil && resp.Content != nil {
 			for _, part := range resp.Content.Parts {
+				if part.Thought {
+					continue
+				}
 				if part.Text != "" {
 					result += part.Text
 				}


### PR DESCRIPTION
修改点：兼容对思考内容用 `<think>` 混合在content字段中的大模型识别，避免将思考内容输出到前端

过滤<think>的逻辑有参考一部分AI提供的建议，修改逻辑供大佬参考

麻烦大佬有空的时候检查看看，如果代码写的不好就不必合并