### PR TITLE
调整AI接口返回空内容时的处理

### DIFF
--- a/internal/meeting/moderator.go
+++ b/internal/meeting/moderator.go
@@ -44,7 +44,9 @@ type DiscussionEntry struct {
 // Analyze 分析用户意图并选择专家
 func (m *Moderator) Analyze(ctx context.Context, stock *models.Stock, query string, agents []models.AgentConfig) (*ModeratorDecision, error) {
 	prompt := m.buildAnalyzePrompt(stock, query, agents)
-	content, err := m.generate(ctx, prompt)
+	content, err := retryRun(ctx, MaxAgentRetries, func() (string, error) {
+		return m.generate(ctx, prompt)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("moderator analyze error: %w", err)
 	}
@@ -54,7 +56,9 @@ func (m *Moderator) Analyze(ctx context.Context, stock *models.Stock, query stri
 // Summarize 总结讨论并给出结论
 func (m *Moderator) Summarize(ctx context.Context, stock *models.Stock, query string, history []DiscussionEntry) (string, error) {
 	prompt := m.buildSummarizePrompt(stock, query, history)
-	return m.generate(ctx, prompt)
+	return retryRun(ctx, MaxAgentRetries, func() (string, error) {
+		return m.generate(ctx, prompt)
+	})
 }
 
 // generate 调用 LLM 生成内容
@@ -82,7 +86,11 @@ func (m *Moderator) generate(ctx context.Context, prompt string) (string, error)
 		}
 	}
 	// 过滤第三方工具调用标记后返回
-	return openai.FilterVendorToolCallMarkers(result.String()), nil
+	cleaned := openai.FilterVendorToolCallMarkers(result.String())
+	if cleaned == "" {
+		return "", fmt.Errorf("模型返回空内容")
+	}
+	return cleaned, nil
 }
 
 // buildAnalyzePrompt 构建意图分析 Prompt

--- a/internal/meeting/service.go
+++ b/internal/meeting/service.go
@@ -29,7 +29,7 @@ var log = logger.New("Meeting")
 // 超时配置常量
 const (
 	MeetingTimeout       = 10 * time.Minute // 整个会议的最大时长
-	AgentTimeout         = 3 * time.Minute  // 单个专家发言的最大时长
+	AgentTimeout         = 5 * time.Minute  // 单个专家发言的最大时长
 	ModeratorTimeout     = 2 * time.Minute  // 小韭菜分析/总结的最大时长
 	ModelCreationTimeout = 15 * time.Second // 模型创建的最大时长
 )
@@ -864,24 +864,32 @@ func (s *Service) runSingleAgent(
 					Detail: part.FunctionResponse.Name,
 				})
 			}
-			if part.Text != "" {
-				// streaming 模式下只累积 Partial 片段，避免重复
-				if progressCallback != nil {
-					if event.LLMResponse.Partial {
-						sb.WriteString(part.Text)
-						progressCallback(ProgressEvent{
-							Type: "streaming", AgentID: cfg.ID, AgentName: cfg.Name,
-							Content: part.Text,
-						})
-					}
-				} else {
+			if part.Text == "" {
+				continue
+			}
+			// streaming 模式下只累积 Partial 片段，避免重复；非 streaming 直接累积
+			if progressCallback != nil {
+				if event.LLMResponse.Partial {
+					sb.WriteString(part.Text)
+					progressCallback(ProgressEvent{
+						Type: "streaming", AgentID: cfg.ID, AgentName: cfg.Name,
+						Content: part.Text,
+					})
+				} else if sb.Len() == 0 {
+					// 兜底：若未收到 Partial 片段，保留一次性响应内容
 					sb.WriteString(part.Text)
 				}
+			} else {
+				sb.WriteString(part.Text)
 			}
 		}
 	}
 
-	return openai.FilterVendorToolCallMarkers(sb.String()), nil
+	cleaned := openai.FilterVendorToolCallMarkers(sb.String())
+	if cleaned == "" {
+		return "", fmt.Errorf("模型返回空内容")
+	}
+	return cleaned, nil
 }
 
 // filterAgentsOrdered 按指定顺序筛选专家（保持小韭菜选择的顺序）


### PR DESCRIPTION
原因: 有些第三方API在失败时有可能会返回空白内容，现有的逻辑空白内容会当作请求成功

修改点:

1. 返回空白内容时视为请求失败走重试逻辑
2. 超时时间调整到了五分钟