### PR TITLE
新增 token 参数名称配置项

### DIFF
--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -17,6 +17,7 @@ interface AIConfig {
   apiKey: string;
   modelName: string;
   maxTokens: number;
+  tokenParamMode?: string;
   temperature: number;
   timeout: number;
   isDefault: boolean;
@@ -39,6 +40,7 @@ interface MemoryConfig {
 
 // 代理模式类型
 type ProxyMode = 'none' | 'system' | 'custom';
+type TokenParamMode = 'auto' | 'max_tokens' | 'max_completion_tokens';
 
 // 代理配置接口
 interface ProxyConfig {
@@ -82,6 +84,17 @@ const useSettingsToast = () => {
   }, []);
 
   return { toast, showToast, hideToast };
+};
+
+const TOKEN_PARAM_OPTIONS: Array<{ value: TokenParamMode; label: string }> = [
+  { value: 'auto', label: '自动（按模型判断）' },
+  { value: 'max_tokens', label: '使用 max_tokens' },
+  { value: 'max_completion_tokens', label: '使用 max_completion_tokens' },
+];
+
+const normalizeTokenParamMode = (value?: string): TokenParamMode => {
+  if (value === 'max_tokens' || value === 'max_completion_tokens') return value;
+  return 'auto';
 };
 
 export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose }) => {
@@ -446,6 +459,7 @@ const ProviderSettings: React.FC<ProviderSettingsProps> = ({ configs, onChange, 
       apiKey: '',
       modelName: getDefaultModel(newProviderType),
       maxTokens: 2048,
+      tokenParamMode: 'auto',
       temperature: 0.7,
       timeout: 60,
       isDefault: configs.length === 0,
@@ -855,10 +869,27 @@ const ProviderEditView: React.FC<ProviderEditViewProps> = ({
         )}
 
         {config.provider === 'openai' && (
-          <div className="flex items-center justify-between">
-            <label className={`text-sm ${colors.isDark ? 'text-slate-400' : 'text-slate-500'}`}>使用 Responses API</label>
-            <ToggleSwitch checked={config.useResponses} onChange={v => onChange({ ...config, useResponses: v })} />
-          </div>
+          <>
+            <div className="flex items-center justify-between">
+              <label className={`text-sm ${colors.isDark ? 'text-slate-400' : 'text-slate-500'}`}>使用 Responses API</label>
+              <ToggleSwitch checked={config.useResponses} onChange={v => onChange({ ...config, useResponses: v })} />
+            </div>
+            <div>
+              <label className={`block text-sm mb-1.5 ${colors.isDark ? 'text-slate-400' : 'text-slate-500'}`}>token 参数名</label>
+              <select
+                value={normalizeTokenParamMode(config.tokenParamMode)}
+                onChange={e => onChange({ ...config, tokenParamMode: e.target.value as TokenParamMode })}
+                className={`w-full fin-input rounded-lg px-3 py-2 text-sm ${colors.isDark ? 'text-white' : 'text-slate-800'}`}
+              >
+                {TOKEN_PARAM_OPTIONS.map(option => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+              <p className={`text-xs mt-1 ${colors.isDark ? 'text-slate-500' : 'text-slate-400'}`}>
+                仅对 OpenAI Chat Completions 生效；自动模式会按模型类型选择参数名。
+              </p>
+            </div>
+          </>
         )}
 
         {isVertexAI && (

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -238,6 +238,7 @@ export namespace models {
 	    apiKey: string;
 	    modelName: string;
 	    maxTokens: number;
+	    tokenParamMode: string;
 	    temperature: number;
 	    timeout: number;
 	    isDefault: boolean;
@@ -260,6 +261,7 @@ export namespace models {
 	        this.apiKey = source["apiKey"];
 	        this.modelName = source["modelName"];
 	        this.maxTokens = source["maxTokens"];
+	        this.tokenParamMode = source["tokenParamMode"];
 	        this.temperature = source["temperature"];
 	        this.timeout = source["timeout"];
 	        this.isDefault = source["isDefault"];

--- a/internal/adk/model_factory.go
+++ b/internal/adk/model_factory.go
@@ -30,6 +30,62 @@ var log = logger.New("ModelFactory")
 
 const cherryStudioUA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) CherryStudio/1.2.4 Chrome/126.0.6478.234 Electron/31.7.6 Safari/537.36"
 
+func setOpenAIChatTokenLimit(body map[string]any, modelName string, tokenParamMode string, limit int) {
+	setOpenAIChatTokenLimitWithResolvedMode(
+		body,
+		openai.ResolveTokenParamMode(modelName, tokenParamMode),
+		limit,
+	)
+}
+
+func setOpenAIChatTokenLimitWithResolvedMode(body map[string]any, resolvedMode string, limit int) {
+	delete(body, "max_tokens")
+	delete(body, "max_completion_tokens")
+
+	switch resolvedMode {
+	case openai.TokenParamModeMaxCompletionTokens:
+		body["max_completion_tokens"] = limit
+	default:
+		body["max_tokens"] = limit
+	}
+}
+
+func alternateOpenAIChatTokenParamMode(resolvedMode string) string {
+	switch resolvedMode {
+	case openai.TokenParamModeMaxCompletionTokens:
+		return openai.TokenParamModeMaxTokens
+	default:
+		return openai.TokenParamModeMaxCompletionTokens
+	}
+}
+
+func isOpenAIChatTokenParamRetryable(statusCode int, respBody []byte) bool {
+	if statusCode < http.StatusBadRequest {
+		return false
+	}
+
+	msg := strings.ToLower(string(respBody))
+	if strings.Contains(msg, "please use maxcompletiontokens") ||
+		strings.Contains(msg, "please use max_completion_tokens") {
+		return true
+	}
+
+	tokenParamNames := []string{"max_tokens", "max_completion_tokens", "maxcompletiontokens"}
+	tokenParamErrors := []string{"unsupported", "not supported", "unknown", "unrecognized", "invalid"}
+	for _, tokenParamName := range tokenParamNames {
+		if !strings.Contains(msg, tokenParamName) {
+			continue
+		}
+		for _, tokenParamError := range tokenParamErrors {
+			if strings.Contains(msg, tokenParamError) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // uaTransport 包装 RoundTripper，自动注入 User-Agent
 type uaTransport struct {
 	base http.RoundTripper
@@ -143,7 +199,7 @@ func (f *ModelFactory) createOpenAIModel(config *models.AIConfig) (model.LLM, er
 		Transport: &uaTransport{base: proxy.GetManager().GetTransport()},
 	}
 
-	return openai.NewOpenAIModel(config.ModelName, openaiCfg, config.NoSystemRole), nil
+	return openai.NewOpenAIModel(config.ModelName, openaiCfg, config.NoSystemRole, string(config.TokenParamMode)), nil
 }
 
 // normalizeAnthropicBaseURL 规范化 Anthropic BaseURL
@@ -240,16 +296,16 @@ func (f *ModelFactory) detectOpenAISystemRole(ctx context.Context, config *model
 	} else {
 		endpoint = strings.TrimSuffix(baseURL, "/") + "/chat/completions"
 		body = map[string]any{
-			"model":      config.ModelName,
-			"max_tokens": 30,
+			"model": config.ModelName,
 			"messages": []map[string]string{
 				{"role": "system", "content": systemPrompt},
 				{"role": "user", "content": "Please follow the system instruction."},
 			},
 		}
+		setOpenAIChatTokenLimit(body, config.ModelName, string(config.TokenParamMode), 30)
 	}
 
-	respBody, statusCode, err := f.doProbeRequest(ctx, endpoint, config.APIKey, transport, body)
+	respBody, statusCode, err := f.doOpenAIProbeRequest(ctx, endpoint, config, transport, body, 30)
 	if err != nil {
 		log.Warn("模型 [%s] system role 探测请求失败: %v", config.ModelName, err)
 		return false
@@ -367,38 +423,22 @@ func (f *ModelFactory) testOpenAIConnection(ctx context.Context, config *models.
 		// 使用 Chat Completions API 端点测试
 		endpoint = strings.TrimSuffix(baseURL, "/") + "/chat/completions"
 		body = map[string]interface{}{
-			"model":      config.ModelName,
-			"max_tokens": 1,
-			"messages":   []map[string]string{{"role": "user", "content": "hi"}},
+			"model":    config.ModelName,
+			"messages": []map[string]string{{"role": "user", "content": "hi"}},
 		}
+		setOpenAIChatTokenLimit(body, config.ModelName, string(config.TokenParamMode), 1)
 	}
 
-	jsonBody, err := json.Marshal(body)
+	respBody, statusCode, err := f.doOpenAIProbeRequest(ctx, endpoint, config, transport, body, 1)
 	if err != nil {
-		return fmt.Errorf("请求构造失败: %w", err)
+		return err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, strings.NewReader(string(jsonBody)))
-	if err != nil {
-		return fmt.Errorf("请求创建失败: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+config.APIKey)
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) CherryStudio/1.2.4 Chrome/126.0.6478.234 Electron/31.7.6 Safari/537.36")
-
-	client := &http.Client{Transport: transport}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("连接失败: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusOK {
+	if statusCode == http.StatusOK {
 		return nil
 	}
 
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-	return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	return fmt.Errorf("HTTP %d: %s", statusCode, string(respBody))
 }
 
 // testGeminiConnection 测试 Gemini 连通性
@@ -509,6 +549,33 @@ func (f *ModelFactory) doProbeRequest(ctx context.Context, endpoint, apiKey stri
 
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
 	return respBody, resp.StatusCode, nil
+}
+
+func (f *ModelFactory) doOpenAIProbeRequest(
+	ctx context.Context,
+	endpoint string,
+	config *models.AIConfig,
+	transport http.RoundTripper,
+	body map[string]any,
+	limit int,
+) ([]byte, int, error) {
+	respBody, statusCode, err := f.doProbeRequest(ctx, endpoint, config.APIKey, transport, body)
+	if err != nil || config.UseResponses {
+		return respBody, statusCode, err
+	}
+	if !isOpenAIChatTokenParamRetryable(statusCode, respBody) {
+		return respBody, statusCode, err
+	}
+
+	resolvedMode := openai.ResolveTokenParamMode(config.ModelName, string(config.TokenParamMode))
+	retryBody := make(map[string]any, len(body))
+	for key, value := range body {
+		retryBody[key] = value
+	}
+	setOpenAIChatTokenLimitWithResolvedMode(retryBody, alternateOpenAIChatTokenParamMode(resolvedMode), limit)
+
+	log.Warn("模型 [%s] 探测请求 token 参数不兼容，切换参数名后重试", config.ModelName)
+	return f.doProbeRequest(ctx, endpoint, config.APIKey, transport, retryBody)
 }
 
 // extractReplyText 从 API 响应 JSON 中提取模型回复文本

--- a/internal/adk/model_factory_test.go
+++ b/internal/adk/model_factory_test.go
@@ -1,6 +1,14 @@
 package adk
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/run-bigpig/jcp/internal/models"
+)
 
 func TestNormalizeAnthropicBaseURL(t *testing.T) {
 	tests := []struct {
@@ -21,5 +29,98 @@ func TestNormalizeAnthropicBaseURL(t *testing.T) {
 				t.Fatalf("normalizeAnthropicBaseURL(%q) = %q, want %q", tc.input, got, tc.wantURL)
 			}
 		})
+	}
+}
+
+func TestTestOpenAIConnection_RetriesAlternateTokenParam(t *testing.T) {
+	requestBodies := make([]map[string]any, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		requestBodies = append(requestBodies, body)
+
+		if _, ok := body["max_tokens"]; ok {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"this model is not supported MaxTokens, please use MaxCompletionTokens"}}`))
+			return
+		}
+		if got := body["max_completion_tokens"]; got != float64(1) {
+			t.Fatalf("max_completion_tokens = %v, want 1", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"ok"}`))
+	}))
+	defer server.Close()
+
+	factory := NewModelFactory()
+	config := &models.AIConfig{
+		Provider:       models.AIProviderOpenAI,
+		BaseURL:        server.URL,
+		APIKey:         "test-key",
+		ModelName:      "prod-assistant",
+		TokenParamMode: models.OpenAITokenParamAuto,
+	}
+
+	if err := factory.TestConnection(context.Background(), config); err != nil {
+		t.Fatalf("TestConnection returned error: %v", err)
+	}
+	if len(requestBodies) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requestBodies))
+	}
+	if _, ok := requestBodies[0]["max_tokens"]; !ok {
+		t.Fatalf("first request should use max_tokens: %+v", requestBodies[0])
+	}
+	if _, ok := requestBodies[1]["max_completion_tokens"]; !ok {
+		t.Fatalf("second request should use max_completion_tokens: %+v", requestBodies[1])
+	}
+}
+
+func TestDetectOpenAISystemRole_RetriesAlternateTokenParam(t *testing.T) {
+	requestBodies := make([]map[string]any, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		requestBodies = append(requestBodies, body)
+
+		if _, ok := body["max_tokens"]; ok {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"unsupported parameter: max_tokens, please use max_completion_tokens"}}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"SYS_PROBE_7X3K"}}]}`))
+	}))
+	defer server.Close()
+
+	factory := NewModelFactory()
+	config := &models.AIConfig{
+		Provider:       models.AIProviderOpenAI,
+		BaseURL:        server.URL,
+		APIKey:         "test-key",
+		ModelName:      "prod-assistant",
+		TokenParamMode: models.OpenAITokenParamAuto,
+	}
+
+	if unsupported := factory.DetectSystemRoleSupport(context.Background(), config); unsupported {
+		t.Fatal("DetectSystemRoleSupport returned unsupported, want supported after retry")
+	}
+	if len(requestBodies) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requestBodies))
+	}
+	if _, ok := requestBodies[1]["max_completion_tokens"]; !ok {
+		t.Fatalf("second request should use max_completion_tokens: %+v", requestBodies[1])
 	}
 }

--- a/internal/adk/openai/convert.go
+++ b/internal/adk/openai/convert.go
@@ -171,7 +171,7 @@ func parseVendorToolCalls(text string) ([]VendorToolCall, string) {
 }
 
 // toOpenAIChatCompletionRequest 将 ADK 请求转换为 OpenAI 请求
-func toOpenAIChatCompletionRequest(req *model.LLMRequest, modelName string, noSystemRole bool) (openai.ChatCompletionRequest, error) {
+func toOpenAIChatCompletionRequest(req *model.LLMRequest, modelName string, noSystemRole bool, tokenParamMode string) (openai.ChatCompletionRequest, error) {
 	openaiMessages := make([]openai.ChatCompletionMessage, 0, len(req.Contents))
 	for _, content := range req.Contents {
 		msgs, err := toOpenAIChatCompletionMessage(content)
@@ -213,7 +213,12 @@ func toOpenAIChatCompletionRequest(req *model.LLMRequest, modelName string, noSy
 			openaiReq.Temperature = *req.Config.Temperature
 		}
 		if req.Config.MaxOutputTokens > 0 {
-			openaiReq.MaxTokens = int(req.Config.MaxOutputTokens)
+			switch ResolveTokenParamMode(modelName, tokenParamMode) {
+			case TokenParamModeMaxCompletionTokens:
+				openaiReq.MaxCompletionTokens = int(req.Config.MaxOutputTokens)
+			default:
+				openaiReq.MaxTokens = int(req.Config.MaxOutputTokens)
+			}
 		}
 		if req.Config.TopP != nil {
 			openaiReq.TopP = *req.Config.TopP

--- a/internal/adk/openai/model.go
+++ b/internal/adk/openai/model.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"iter"
 	"slices"
+	"strings"
 
 	"github.com/sashabaranov/go-openai"
 	"google.golang.org/adk/model"
@@ -25,18 +26,20 @@ var (
 
 // OpenAIModel 实现 model.LLM 接口，支持 thinking 模型
 type OpenAIModel struct {
-	Client       *openai.Client
-	ModelName    string
-	NoSystemRole bool // 不支持 system role 时需要降级处理
+	Client         *openai.Client
+	ModelName      string
+	TokenParamMode string
+	NoSystemRole   bool // 不支持 system role 时需要降级处理
 }
 
 // NewOpenAIModel 创建 OpenAI 模型
-func NewOpenAIModel(modelName string, cfg openai.ClientConfig, noSystemRole bool) *OpenAIModel {
+func NewOpenAIModel(modelName string, cfg openai.ClientConfig, noSystemRole bool, tokenParamMode string) *OpenAIModel {
 	client := openai.NewClientWithConfig(cfg)
 	return &OpenAIModel{
-		Client:       client,
-		ModelName:    modelName,
-		NoSystemRole: noSystemRole,
+		Client:         client,
+		ModelName:      modelName,
+		TokenParamMode: tokenParamMode,
+		NoSystemRole:   noSystemRole,
 	}
 }
 
@@ -56,13 +59,20 @@ func (o *OpenAIModel) GenerateContent(ctx context.Context, req *model.LLMRequest
 // generate 非流式生成
 func (o *OpenAIModel) generate(ctx context.Context, req *model.LLMRequest) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
-		openaiReq, err := toOpenAIChatCompletionRequest(req, o.ModelName, o.NoSystemRole)
+		openaiReq, err := toOpenAIChatCompletionRequest(req, o.ModelName, o.NoSystemRole, o.TokenParamMode)
 		if err != nil {
 			yield(nil, err)
 			return
 		}
 
 		resp, err := o.Client.CreateChatCompletion(ctx, openaiReq)
+		if err != nil {
+			retryReq, ok := buildCompatRetryRequest(openaiReq, err)
+			if ok {
+				modelLog.Warn("模型 [%s] 首次请求参数不兼容，已自动调整后重试: %v", o.ModelName, err)
+				resp, err = o.Client.CreateChatCompletion(ctx, retryReq)
+			}
+		}
 		if err != nil {
 			yield(nil, err)
 			return
@@ -81,7 +91,7 @@ func (o *OpenAIModel) generate(ctx context.Context, req *model.LLMRequest) iter.
 // generateStream 流式生成
 func (o *OpenAIModel) generateStream(ctx context.Context, req *model.LLMRequest) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
-		openaiReq, err := toOpenAIChatCompletionRequest(req, o.ModelName, o.NoSystemRole)
+		openaiReq, err := toOpenAIChatCompletionRequest(req, o.ModelName, o.NoSystemRole, o.TokenParamMode)
 		if err != nil {
 			yield(nil, err)
 			return
@@ -90,6 +100,14 @@ func (o *OpenAIModel) generateStream(ctx context.Context, req *model.LLMRequest)
 
 		stream, err := o.Client.CreateChatCompletionStream(ctx, openaiReq)
 		if err != nil {
+			retryReq, ok := buildCompatRetryRequest(openaiReq, err)
+			if ok {
+				retryReq.Stream = true
+				modelLog.Warn("模型 [%s] 首次流式请求参数不兼容，已自动调整后重试: %v", o.ModelName, err)
+				stream, err = o.Client.CreateChatCompletionStream(ctx, retryReq)
+			}
+		}
+		if err != nil {
 			yield(nil, err)
 			return
 		}
@@ -97,6 +115,58 @@ func (o *OpenAIModel) generateStream(ctx context.Context, req *model.LLMRequest)
 
 		o.processStream(stream, yield)
 	}
+}
+
+func buildCompatRetryRequest(req openai.ChatCompletionRequest, err error) (openai.ChatCompletionRequest, bool) {
+	if !isCompatRetryableError(err) {
+		return req, false
+	}
+
+	changed := false
+	if req.MaxTokens > 0 && req.MaxCompletionTokens == 0 {
+		req.MaxCompletionTokens = req.MaxTokens
+		req.MaxTokens = 0
+		changed = true
+	}
+	if req.Temperature != 0 && req.Temperature != 1 {
+		req.Temperature = 1
+		changed = true
+	}
+	if req.TopP != 0 && req.TopP != 1 {
+		req.TopP = 1
+		changed = true
+	}
+	if req.N != 0 && req.N != 1 {
+		req.N = 1
+		changed = true
+	}
+	if req.PresencePenalty != 0 {
+		req.PresencePenalty = 0
+		changed = true
+	}
+	if req.FrequencyPenalty != 0 {
+		req.FrequencyPenalty = 0
+		changed = true
+	}
+
+	return req, changed
+}
+
+func isCompatRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, openai.ErrReasoningModelMaxTokensDeprecated) ||
+		errors.Is(err, openai.ErrReasoningModelLimitationsOther) ||
+		errors.Is(err, openai.ErrO1MaxTokensDeprecated) ||
+		errors.Is(err, openai.ErrO1BetaLimitationsOther) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "please use maxcompletiontokens") ||
+		strings.Contains(msg, "please use max_completion_tokens") ||
+		strings.Contains(msg, "temperature, top_p and n are fixed at 1")
 }
 
 // processStream 处理流式响应

--- a/internal/adk/openai/token_param.go
+++ b/internal/adk/openai/token_param.go
@@ -1,0 +1,42 @@
+package openai
+
+import "strings"
+
+const (
+	TokenParamModeAuto                = "auto"
+	TokenParamModeMaxTokens           = "max_tokens"
+	TokenParamModeMaxCompletionTokens = "max_completion_tokens"
+)
+
+func ResolveTokenParamMode(modelName string, mode string) string {
+	switch normalizeTokenParamMode(mode) {
+	case TokenParamModeMaxTokens:
+		return TokenParamModeMaxTokens
+	case TokenParamModeMaxCompletionTokens:
+		return TokenParamModeMaxCompletionTokens
+	default:
+		if isReasoningStyleModel(modelName) {
+			return TokenParamModeMaxCompletionTokens
+		}
+		return TokenParamModeMaxTokens
+	}
+}
+
+func normalizeTokenParamMode(mode string) string {
+	switch strings.TrimSpace(strings.ToLower(mode)) {
+	case TokenParamModeMaxTokens:
+		return TokenParamModeMaxTokens
+	case TokenParamModeMaxCompletionTokens:
+		return TokenParamModeMaxCompletionTokens
+	default:
+		return TokenParamModeAuto
+	}
+}
+
+func isReasoningStyleModel(modelName string) bool {
+	modelName = strings.TrimSpace(strings.ToLower(modelName))
+	return strings.HasPrefix(modelName, "gpt-5") ||
+		strings.HasPrefix(modelName, "o1") ||
+		strings.HasPrefix(modelName, "o3") ||
+		strings.HasPrefix(modelName, "o4")
+}

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -10,18 +10,27 @@ const (
 	AIProviderAnthropic AIProvider = "anthropic"
 )
 
+type OpenAITokenParamMode string
+
+const (
+	OpenAITokenParamAuto                OpenAITokenParamMode = "auto"
+	OpenAITokenParamMaxTokens           OpenAITokenParamMode = "max_tokens"
+	OpenAITokenParamMaxCompletionTokens OpenAITokenParamMode = "max_completion_tokens"
+)
+
 // AIConfig AI服务配置
 type AIConfig struct {
-	ID          string     `json:"id"`
-	Name        string     `json:"name"`
-	Provider    AIProvider `json:"provider"`
-	BaseURL     string     `json:"baseUrl"`
-	APIKey      string     `json:"apiKey"`
-	ModelName   string     `json:"modelName"`
-	MaxTokens   int        `json:"maxTokens"`
-	Temperature float64    `json:"temperature"`
-	Timeout     int        `json:"timeout"`
-	IsDefault   bool       `json:"isDefault"`
+	ID             string               `json:"id"`
+	Name           string               `json:"name"`
+	Provider       AIProvider           `json:"provider"`
+	BaseURL        string               `json:"baseUrl"`
+	APIKey         string               `json:"apiKey"`
+	ModelName      string               `json:"modelName"`
+	MaxTokens      int                  `json:"maxTokens"`
+	TokenParamMode OpenAITokenParamMode `json:"tokenParamMode"`
+	Temperature    float64              `json:"temperature"`
+	Timeout        int                  `json:"timeout"`
+	IsDefault      bool                 `json:"isDefault"`
 	// OpenAI Responses API 开关
 	UseResponses bool `json:"useResponses"`
 	// 不支持 system role（自动检测，用户不可见）
@@ -46,11 +55,11 @@ type MCPServerConfig struct {
 	ID            string           `json:"id"`
 	Name          string           `json:"name"`
 	TransportType MCPTransportType `json:"transportType"`
-	Endpoint      string           `json:"endpoint"`      // HTTP/SSE 端点 URL
-	Command       string           `json:"command"`       // 命令行传输的命令
-	Args          []string         `json:"args"`          // 命令行参数
-	ToolFilter    []string         `json:"toolFilter"`    // 工具过滤列表（空则全部）
-	Enabled       bool             `json:"enabled"`       // 是否启用
+	Endpoint      string           `json:"endpoint"`   // HTTP/SSE 端点 URL
+	Command       string           `json:"command"`    // 命令行传输的命令
+	Args          []string         `json:"args"`       // 命令行参数
+	ToolFilter    []string         `json:"toolFilter"` // 工具过滤列表（空则全部）
+	Enabled       bool             `json:"enabled"`    // 是否启用
 }
 
 // AppConfig 应用配置


### PR DESCRIPTION
修复 [#32](https://github.com/run-bigpig/jcp/issues/32) 中 OpenAI Chat Completions 的 token 参数兼容问题。

新增 token 参数名称配置项


<img width="1122" height="580" alt="image" src="https://github.com/user-attachments/assets/d9f339c4-edce-4b11-a8ac-84313710a240" />


